### PR TITLE
Added force string type to 3rd argument of preg_replace in `util::log()`

### DIFF
--- a/lib/net/authorize/util/Log.php
+++ b/lib/net/authorize/util/Log.php
@@ -159,7 +159,7 @@ class Log
 			
 			if(strcmp($prop->getName(),$sensitiveField->tagName)==0)
 			{
-				$prop->setValue($obj,preg_replace($inputPattern,$inputReplacement,$prop->getValue($obj)));
+				$prop->setValue($obj,preg_replace($inputPattern,$inputReplacement,(string)$prop->getValue($obj)));
 				return $prop->getValue($obj);
 			}
 		}


### PR DESCRIPTION
Added force string type to 3rd argument of preg_replace in `util::log()` which would otherwise throw a deprecated error for passing `null` in certain instances. For example, attempting to omit the `cardCode` value on "Stored Card" transaction where the card code is not known, while SDK logging is enabled, would cause the affected line to attempt to perform `preg_replace` on a null value when parsing the card code value.